### PR TITLE
refactor: change Emit to return `*http.Response, error`

### DIFF
--- a/alertmanager.go
+++ b/alertmanager.go
@@ -63,10 +63,6 @@ func NewAlertmanager(logger logr.Logger, client *http.Client, options ...Manager
 
 // Emit sends one or more alerts to Alertmanager.
 func (a *Alertmanager) Emit(alerts ...*Alert) (*http.Response, error) {
-	if len(alerts) == 0 {
-		return nil, nil
-	}
-
 	if a.endpoint == "" {
 		return nil, ErrEndpointRequired
 	}

--- a/alertmanager.go
+++ b/alertmanager.go
@@ -19,9 +19,6 @@ var (
 	// ErrEndpointRequired is returned when the Alertmanager endpoint is not provided.
 	ErrEndpointRequired = errors.New("invalid Alertmanager config: endpoint required")
 
-	// ErrEmissionFailed is returned when alert emission fails.
-	ErrEmissionFailed = errors.New("emission failed")
-
 	// ErrNilHTTPClient is returned when a nil HTTP client is provided.
 	ErrNilHTTPClient = errors.New("HTTP client cannot be nil")
 )
@@ -65,13 +62,13 @@ func NewAlertmanager(logger logr.Logger, client *http.Client, options ...Manager
 }
 
 // Emit sends one or more alerts to Alertmanager.
-func (a *Alertmanager) Emit(alerts ...*Alert) error {
+func (a *Alertmanager) Emit(alerts ...*Alert) (*http.Response, error) {
 	if len(alerts) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	if a.endpoint == "" {
-		return ErrEndpointRequired
+		return nil, ErrEndpointRequired
 	}
 
 	finalAlerts := make([]Alert, 0, len(alerts))
@@ -98,15 +95,12 @@ func (a *Alertmanager) Emit(alerts ...*Alert) error {
 
 	body, err := json.Marshal(finalAlerts)
 	if err != nil {
-		a.log.Error(err, "failed to marshal alerts", "alerts", finalAlerts)
-		return err
+		return nil, fmt.Errorf("failed to marshal alerts: %w", err)
 	}
-	a.log.V(1).Info("Alertmanager message", "payload", string(body))
 
 	req, err := http.NewRequest(http.MethodPost, a.endpoint, bytes.NewReader(body))
 	if err != nil {
-		a.log.Error(err, "failed to create HTTP POST request", "endpoint", a.endpoint)
-		return err
+		return nil, fmt.Errorf("failed to create HTTP request to %s: %w", a.endpoint, err)
 	}
 	req.Header.Add("Content-Type", "application/json")
 
@@ -115,22 +109,11 @@ func (a *Alertmanager) Emit(alerts ...*Alert) error {
 	}
 
 	resp, err := a.client.Do(req)
-	defer func() {
-		if resp != nil {
-			_ = resp.Body.Close()
-		}
-	}()
 	if err != nil {
-		a.log.Error(err, "failed to post alert", "endpoint", a.endpoint)
-		return err
-	}
-	if resp.StatusCode != 200 {
-		a.log.V(0).Info("failed to post alert", "endpoint", a.endpoint, "status", resp.Status, "code", resp.StatusCode)
-		return ErrEmissionFailed
+		return nil, fmt.Errorf("failed to post alert to %s: %w", a.endpoint, err)
 	}
 
-	a.log.V(0).Info("Successfully posted alert to Alertmanager", "endpoint", a.endpoint, "status", resp.Status, "code", resp.StatusCode)
-	return nil
+	return resp, nil
 }
 
 func basicAuthHeader(username, password string) (string, string) {

--- a/alertmanager_test.go
+++ b/alertmanager_test.go
@@ -224,6 +224,9 @@ func TestEmit(t *testing.T) {
 			}
 
 			resp, err := am.Emit(tt.alerts...)
+			if resp != nil {
+				defer resp.Body.Close()
+			}
 
 			if tt.expectedError != nil {
 				if err == nil {
@@ -238,14 +241,16 @@ func TestEmit(t *testing.T) {
 
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
+				return
 			}
 
-			if resp != nil {
-				defer resp.Body.Close()
-
-				// For the "server returns error" test, verify we get the 500 status
-				if tt.name == "server returns error" && resp.StatusCode != http.StatusInternalServerError {
+			if tt.name == "server returns error" {
+				if resp.StatusCode != http.StatusInternalServerError {
 					t.Errorf("expected status code %d, got %d", http.StatusInternalServerError, resp.StatusCode)
+				}
+			} else {
+				if resp.StatusCode != http.StatusOK {
+					t.Errorf("expected status code %d, got %d", http.StatusOK, resp.StatusCode)
 				}
 			}
 		})

--- a/examples/audit/main.go
+++ b/examples/audit/main.go
@@ -63,10 +63,12 @@ func main() {
 		alertmanager.WithAnnotation("summary", "ConfigMap created"),
 		alertmanager.WithAnnotation("description", fmt.Sprintf("User %s created ConfigMap %s/%s", user, resourceNamespace, resourceName)),
 	)
-	if err := am.Emit(createAlert); err != nil {
+	resp, err := am.Emit(createAlert)
+	if err != nil {
 		fmt.Printf("Failed to send CREATE alert: %v\n", err)
 		return
 	}
+	resp.Body.Close()
 
 	// Operation 2: Update ConfigMap
 	auditID, err = generateAuditID()
@@ -87,10 +89,12 @@ func main() {
 		alertmanager.WithAnnotation("summary", "ConfigMap updated"),
 		alertmanager.WithAnnotation("description", fmt.Sprintf("User %s updated ConfigMap %s/%s", user, resourceNamespace, resourceName)),
 	)
-	if err := am.Emit(updateAlert); err != nil {
+	resp, err = am.Emit(updateAlert)
+	if err != nil {
 		fmt.Printf("Failed to send UPDATE alert: %v\n", err)
 		return
 	}
+	resp.Body.Close()
 
 	// Operation 3: Update ConfigMap again
 	auditID, err = generateAuditID()
@@ -111,10 +115,12 @@ func main() {
 		alertmanager.WithAnnotation("summary", "ConfigMap updated"),
 		alertmanager.WithAnnotation("description", fmt.Sprintf("User %s updated ConfigMap %s/%s", user, resourceNamespace, resourceName)),
 	)
-	if err := am.Emit(updateAlert2); err != nil {
+	resp, err = am.Emit(updateAlert2)
+	if err != nil {
 		fmt.Printf("Failed to send UPDATE alert: %v\n", err)
 		return
 	}
+	resp.Body.Close()
 
 	// Operation 4: Delete ConfigMap
 	auditID, err = generateAuditID()
@@ -135,10 +141,12 @@ func main() {
 		alertmanager.WithAnnotation("summary", "ConfigMap deleted"),
 		alertmanager.WithAnnotation("description", fmt.Sprintf("User %s deleted ConfigMap %s/%s", user, resourceNamespace, resourceName)),
 	)
-	if err := am.Emit(deleteAlert); err != nil {
+	resp, err = am.Emit(deleteAlert)
+	if err != nil {
 		fmt.Printf("Failed to send DELETE alert: %v\n", err)
 		return
 	}
+	resp.Body.Close()
 
 	// Operation 5: Re-create ConfigMap
 	auditID, err = generateAuditID()
@@ -159,10 +167,12 @@ func main() {
 		alertmanager.WithAnnotation("summary", "ConfigMap created"),
 		alertmanager.WithAnnotation("description", fmt.Sprintf("User %s created ConfigMap %s/%s", user, resourceNamespace, resourceName)),
 	)
-	if err := am.Emit(recreateAlert); err != nil {
+	resp, err = am.Emit(recreateAlert)
+	if err != nil {
 		fmt.Printf("Failed to send CREATE alert: %v\n", err)
 		return
 	}
+	resp.Body.Close()
 
 	fmt.Println("\nSuccessfully sent 5 audit log alerts to Alertmanager!")
 	fmt.Println("\nEach alert has a unique audit_id label to prevent deduplication.")

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -53,9 +53,15 @@ func main() {
 
 	// Emit all alerts at once
 	fmt.Println("Sending alerts to Alertmanager...")
-	err = am.Emit(alerts...)
+	resp, err := am.Emit(alerts...)
 	if err != nil {
 		fmt.Printf("Failed to send alerts: %v\n", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		fmt.Printf("Alertmanager returned non-OK status: %d %s\n", resp.StatusCode, resp.Status)
 		return
 	}
 

--- a/examples/time/main.go
+++ b/examples/time/main.go
@@ -76,9 +76,15 @@ func main() {
 	fmt.Println("Sending alerts to Alertmanager...")
 	fmt.Printf("Current time: %s\n\n", now.Format(time.RFC3339))
 
-	err = am.Emit(alerts...)
+	resp, err := am.Emit(alerts...)
 	if err != nil {
 		fmt.Printf("Failed to send alerts: %v\n", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		fmt.Printf("Alertmanager returned non-OK status: %d %s\n", resp.StatusCode, resp.Status)
 		return
 	}
 


### PR DESCRIPTION
Updates the `Emit` function to follow Go's standard HTTP client pattern by returning `(*http.Response, error)` instead of just `error`, matching the behavior of `http.Client.Do()`. This change makes the API more ergonomic and gives callers full control over response inspection and error handling.
